### PR TITLE
feat: add mobile home with favorites and metrics

### DIFF
--- a/frontend/src/Routes.jsx
+++ b/frontend/src/Routes.jsx
@@ -17,6 +17,7 @@ import LoginPage from './pages/login';
 import AdminDashboard from './pages/admin-dashboard';
 import ContentManagement from './pages/content-management';
 import MedicationSearch from './pages/medication-search';
+import HomePage from './pages/home';
 import MedicationDetails from './pages/medication-details';
 import NotFound from "pages/NotFound";
 
@@ -51,7 +52,15 @@ const Routes = () => {
             
             {/* Protected Clinical Routes */}
             <Route
-              path="/medication-search" 
+              path="/home"
+              element={
+                <AuthenticationGate requiredRole="clinical">
+                  <HomePage />
+                </AuthenticationGate>
+              }
+            />
+            <Route
+              path="/medication-search"
               element={
                 <AuthenticationGate requiredRole="clinical">
                   <MedicationSearch />
@@ -59,14 +68,13 @@ const Routes = () => {
               }
             />
             <Route
-              path="/medication-details/:id" 
+              path="/medication-details/:id"
               element={
                 <AuthenticationGate requiredRole="clinical">
                   <MedicationDetails />
                 </AuthenticationGate>
               }
             />
-            
             {/* Fallback */}
             <Route path="*" element={<NotFound />} />
           </RouterRoutes>

--- a/frontend/src/components/ui/ClinicalSearchHeader.jsx
+++ b/frontend/src/components/ui/ClinicalSearchHeader.jsx
@@ -58,7 +58,7 @@ const ClinicalSearchHeader = ({
     } else if (onSearchChange) {
       onSearchChange('');
     }
-    navigate('/medication-search');
+    navigate('/home');
     window.location.reload();
   };
 
@@ -96,7 +96,7 @@ const ClinicalSearchHeader = ({
             <Input
               id="search-input"
               type="search"
-              placeholder="Buscar sedoanalgésicos, dosis, protocolos..."
+              placeholder="Buscar sedoanalgésicos, dosis, diluciones…"
               value={searchQuery}
               onChange={(e) => onSearchChange && onSearchChange(e?.target?.value)}
               onFocus={() => onSearchFocus && onSearchFocus()}

--- a/frontend/src/pages/admin-dashboard/index.jsx
+++ b/frontend/src/pages/admin-dashboard/index.jsx
@@ -202,7 +202,7 @@ const AdminDashboard = () => {
   }, []);
 
   const handleTestClinicalView = () => {
-    navigate('/medication-search');
+    navigate('/home');
   };
 
   if (isLoading) {

--- a/frontend/src/pages/home/components/SectionAtajos.jsx
+++ b/frontend/src/pages/home/components/SectionAtajos.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import Icon from '../../../components/AppIcon';
+
+const shortcuts = [
+  { id: 'midaz', label: 'Midazolam', icon: 'Moon' },
+  { id: 'ket', label: 'Ketamina', icon: 'FlaskConical' },
+  { id: 'prop', label: 'Propofol', icon: 'Droplet' },
+  { id: 'fenta', label: 'Fentanilo', icon: 'Syringe' },
+];
+
+const SectionAtajos = () => {
+  return (
+    <section>
+      <h2 className="text-lg font-semibold mb-3">Atajos por tarea</h2>
+      <div className="flex flex-wrap gap-3">
+        {shortcuts.map(sc => (
+          <div key={sc.id} className="px-4 py-2 bg-blue-50 rounded-full flex items-center space-x-2">
+            <Icon name={sc.icon} size={16} className="text-primary" />
+            <span className="text-sm font-medium">{sc.label}</span>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+};
+
+export default SectionAtajos;

--- a/frontend/src/pages/home/components/SectionCategorias.jsx
+++ b/frontend/src/pages/home/components/SectionCategorias.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import Icon from '../../../components/AppIcon';
+
+const categories = [
+  { id: 'sed', label: 'Sedoanalgésicos', icon: 'Pill', color: 'bg-blue-50', route: '/medication-search' },
+  { id: 'dil', label: 'Diluciones', icon: 'Beaker', color: 'bg-purple-50', route: '/medication-search?filter=diluciones' },
+  { id: 'est', label: 'Estabilidad & Luz', icon: 'Sun', color: 'bg-yellow-50', route: '/medication-search?filter=estabilidad' },
+];
+
+const SectionCategorias = () => {
+  const navigate = useNavigate();
+  return (
+    <section>
+      <h2 className="text-lg font-semibold mb-3">Acceso por categorías</h2>
+      <div className="grid grid-cols-3 gap-4">
+        {categories.map(cat => (
+          <button
+            key={cat.id}
+            onClick={() => navigate(cat.route)}
+            className={`${cat.color} rounded-xl p-4 flex flex-col items-center justify-center text-center clinical-shadow hover:shadow-md`}
+          >
+            <Icon name={cat.icon} size={24} className="text-primary mb-2" />
+            <span className="text-sm font-medium leading-tight">{cat.label}</span>
+          </button>
+        ))}
+      </div>
+    </section>
+  );
+};
+
+export default SectionCategorias;

--- a/frontend/src/pages/home/components/SectionFavoritos.jsx
+++ b/frontend/src/pages/home/components/SectionFavoritos.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import Icon from '../../../components/AppIcon';
+
+const SectionFavoritos = ({ items, onToggle }) => {
+  const navigate = useNavigate();
+  return (
+    <section>
+      <h2 className="text-lg font-semibold mb-3">Mis favoritos</h2>
+      {items.length === 0 ? (
+        <p className="text-slate-500">Aún no tienes favoritos · Marca ★ en cualquier fármaco</p>
+      ) : (
+        <ul className="bg-white rounded-xl clinical-shadow divide-y">
+          {items.map(m => (
+            <li key={m.id} className="flex items-center justify-between p-4">
+              <button onClick={() => navigate(`/medication-details?id=${m.id}`)} className="text-left">
+                <p className="font-medium">{m.nombre}</p>
+                <p className="text-sm text-slate-500">{m.unidad} · {m.via}</p>
+              </button>
+              <button onClick={() => onToggle(m.id)} aria-label="Quitar de favoritos" className="text-warning">
+                <Icon name="Star" size={18} />
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+};
+
+export default SectionFavoritos;

--- a/frontend/src/pages/home/components/SectionMasBuscados.jsx
+++ b/frontend/src/pages/home/components/SectionMasBuscados.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import Icon from '../../../components/AppIcon';
+
+const SectionMasBuscados = ({ items }) => {
+  const navigate = useNavigate();
+  if (items.length === 0) {
+    return (
+      <section>
+        <h2 className="text-lg font-semibold mb-2">Más buscados</h2>
+        <p className="text-slate-500">Aún no hay búsquedas suficientes</p>
+      </section>
+    );
+  }
+  return (
+    <section>
+      <h2 className="text-lg font-semibold mb-3">Más buscados</h2>
+      <div className="flex flex-wrap gap-3">
+        {items.map(m => (
+          <button
+            key={m.id}
+            onClick={() => navigate(`/medication-details?id=${m.id}`)}
+            className="px-4 py-2 bg-white rounded-full clinical-shadow hover:shadow-md flex items-center space-x-2"
+          >
+            <Icon name="TrendingUp" size={16} className="text-primary" />
+            <span className="text-sm font-medium">{m.nombre}</span>
+          </button>
+        ))}
+      </div>
+    </section>
+  );
+};
+
+export default SectionMasBuscados;

--- a/frontend/src/pages/home/components/SectionNovedades.jsx
+++ b/frontend/src/pages/home/components/SectionNovedades.jsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+
+const SectionNovedades = ({ items }) => {
+  const navigate = useNavigate();
+  return (
+    <section>
+      <div className="flex items-center justify-between mb-3">
+        <h2 className="text-lg font-semibold">Novedades</h2>
+        {items.length > 0 && (
+          <span className="text-xs bg-primary text-white rounded-full px-2 py-0.5">{items.length}</span>
+        )}
+      </div>
+      {items.length === 0 ? (
+        <p className="text-slate-500">Sin novedades por ahora</p>
+      ) : (
+        <div className="flex space-x-4 overflow-x-auto pb-2">
+          {items.map(m => (
+            <div
+              key={m.id}
+              className="min-w-[180px] p-4 bg-white rounded-xl clinical-shadow hover:shadow-md transition-shadow flex-shrink-0"
+              onClick={() => navigate(`/medication-details?id=${m.id}`)}
+            >
+              <h3 className="font-medium mb-2">{m.nombre}</h3>
+              <div className="flex flex-wrap gap-1 text-xs">
+                <span className="px-2 py-0.5 bg-slate-100 rounded-full">{m.via}</span>
+                {m.fotosensible && <span className="px-2 py-0.5 bg-slate-100 rounded-full">Fotosensible</span>}
+                {m.estabilidadHoras && <span className="px-2 py-0.5 bg-slate-100 rounded-full">{m.estabilidadHoras} h</span>}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+};
+
+export default SectionNovedades;

--- a/frontend/src/pages/home/index.jsx
+++ b/frontend/src/pages/home/index.jsx
@@ -1,0 +1,104 @@
+import React, { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import Icon from '../../components/AppIcon';
+import SearchBar from '../medication-search/components/SearchBar';
+import { useFavorites } from '../../utils/favorites';
+import SectionCategorias from './components/SectionCategorias';
+import SectionNovedades from './components/SectionNovedades';
+import SectionMasBuscados from './components/SectionMasBuscados';
+import SectionFavoritos from './components/SectionFavoritos';
+import SectionAtajos from './components/SectionAtajos';
+import VoiceSearchButton from '../medication-search/components/VoiceSearchButton';
+import { getTopSearches } from '../../utils/searchMetrics';
+
+const medications = [
+  { id: '1', nombre: 'Midazolam', via: 'Central', unidad: 'mg/kg/h', fotosensible: true, estabilidadHoras: 24, actualizadoEn: '2024-06-10T00:00:00Z' },
+  { id: '2', nombre: 'Fentanilo', via: 'Periférica', unidad: 'mcg/kg/h', fotosensible: false, estabilidadHoras: 48, actualizadoEn: '2024-06-08T00:00:00Z' },
+  { id: '3', nombre: 'Propofol', via: 'Central', unidad: 'mg/kg/h', fotosensible: true, estabilidadHoras: 12 },
+];
+
+const isRecent = (dateStr) => {
+  if (!dateStr) return false;
+  const diff = Date.now() - new Date(dateStr).getTime();
+  return diff <= 7 * 24 * 60 * 60 * 1000;
+};
+
+const HomePage = () => {
+  const navigate = useNavigate();
+  const [query, setQuery] = useState('');
+  const { favorites, toggleFavorite } = useFavorites();
+  const [isVoiceActive, setIsVoiceActive] = useState(false);
+  const [isVoiceSupported, setIsVoiceSupported] = useState(false);
+
+  useEffect(() => {
+    const SpeechRecognition = window.SpeechRecognition || window.webkitSpeechRecognition;
+    if (SpeechRecognition) {
+      setIsVoiceSupported(true);
+    }
+  }, []);
+
+  const novedades = medications.filter(m => isRecent(m.actualizadoEn)).sort((a,b) => new Date(b.actualizadoEn) - new Date(a.actualizadoEn)).slice(0,10);
+  const topBuscados = getTopSearches(8).map(id => medications.find(m => m.id === id)).filter(Boolean);
+  const favoritos = favorites.map(id => medications.find(m => m.id === id)).filter(Boolean);
+
+  const handleSearch = (term) => {
+    if (term?.trim()) {
+      navigate('/medication-search', { state: { query: term } });
+    }
+  };
+
+  const onStartVoice = () => {
+    if (!isVoiceSupported) return;
+    const SpeechRecognition = window.SpeechRecognition || window.webkitSpeechRecognition;
+    const recognition = new SpeechRecognition();
+    recognition.lang = 'es-ES';
+    recognition.onstart = () => setIsVoiceActive(true);
+    recognition.onresult = (event) => {
+      const transcript = event.results[0][0].transcript;
+      setQuery(transcript);
+      handleSearch(transcript);
+    };
+    recognition.onerror = () => setIsVoiceActive(false);
+    recognition.onend = () => setIsVoiceActive(false);
+    recognition.start();
+  };
+
+  return (
+    <div className="min-h-screen bg-white">
+      {/* AppBar */}
+      <header className="sticky top-0 bg-white border-b border-slate-200 z-50">
+        <div className="flex items-center p-4 space-x-3">
+          <div className="flex items-center space-x-2">
+            <Icon name="Syringe" size={24} />
+            <span className="font-semibold">SedoAnalgesia</span>
+          </div>
+          <div className="flex-1">
+            <SearchBar
+              searchQuery={query}
+              onSearchChange={setQuery}
+            />
+          </div>
+          <button className="w-10 h-10 rounded-full bg-slate-200 flex items-center justify-center" aria-label="Perfil">
+            <Icon name="User" size={20} />
+          </button>
+        </div>
+      </header>
+
+      <main className="p-4 space-y-8 pb-32">
+        <SectionCategorias />
+
+        <SectionNovedades items={novedades} />
+
+        <SectionMasBuscados items={topBuscados} />
+
+        <SectionFavoritos items={favoritos} onToggle={toggleFavorite} />
+
+        <SectionAtajos />
+      </main>
+
+      <VoiceSearchButton isActive={isVoiceActive} onStartVoice={onStartVoice} isSupported={isVoiceSupported} />
+    </div>
+  );
+};
+
+export default HomePage;

--- a/frontend/src/pages/login/components/LoginForm.jsx
+++ b/frontend/src/pages/login/components/LoginForm.jsx
@@ -111,7 +111,7 @@ const LoginForm = ({ currentLanguage, onLanguageChange }) => {
 
       // Navigate based on role
       if (formData?.role === 'clinico') {
-        navigate('/medication-search');
+        navigate('/home');
       } else {
         navigate('/admin-dashboard');
       }

--- a/frontend/src/pages/login/index.jsx
+++ b/frontend/src/pages/login/index.jsx
@@ -20,7 +20,7 @@ const LoginPage = () => {
   useEffect(() => {
     if (isAuthenticated) {
       if (userRole === 'clinical') {
-        navigate('/medication-search');
+        navigate('/home');
       } else {
         navigate('/admin-dashboard');
       }
@@ -59,7 +59,7 @@ const LoginPage = () => {
 
       // Navigate based on role
       if (formData?.role === 'clinical') {
-        navigate('/medication-search');
+        navigate('/home');
       } else {
         navigate('/admin-dashboard');
       }

--- a/frontend/src/pages/medication-details/components/RelatedMedications.jsx
+++ b/frontend/src/pages/medication-details/components/RelatedMedications.jsx
@@ -87,7 +87,7 @@ const RelatedMedications = ({ relatedMedications }) => {
       <div className="mt-6 pt-4 border-t border-border">
         <Button
           variant="outline"
-          onClick={() => navigate('/medication-search')}
+          onClick={() => navigate('/home')}
           className="w-full"
         >
           <Icon name="Search" size={18} className="mr-2" />

--- a/frontend/src/pages/medication-details/index.jsx
+++ b/frontend/src/pages/medication-details/index.jsx
@@ -12,18 +12,21 @@ import QuickActions from './components/QuickActions';
 import Icon from '../../components/AppIcon';
 import Button from '../../components/ui/Button';
 
+import { useFavorites } from "../../utils/favorites";
+import { incrementSearchCount } from "../../utils/searchMetrics";
 
 
 const MedicationDetails = () => {
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
   const { isAuthenticated, userRole } = useNavigation();
+  const { favorites, toggleFavorite } = useFavorites();
+  const medicationId = searchParams?.get('id') || '1';
+  useEffect(() => { incrementSearchCount(medicationId); }, [medicationId]);
   const [medication, setMedication] = useState(null);
-  const [isFavorite, setIsFavorite] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
   const [searchQuery, setSearchQuery] = useState('');
-
-  const medicationId = searchParams?.get('id') || '1';
+  const isFavorite = favorites.includes(medicationId);
 
   // Mock medication data
   const mockMedications = {
@@ -222,10 +225,6 @@ const MedicationDetails = () => {
       if (medicationData) {
         setMedication(medicationData);
         
-        // Check if medication is in favorites
-        const favorites = JSON.parse(localStorage.getItem('clinicalDict_favorites') || '[]');
-        setIsFavorite(favorites?.includes(medicationId));
-        
         // Add to recently viewed
         const recentlyViewed = JSON.parse(localStorage.getItem('clinicalDict_recentlyViewed') || '[]');
         const updated = [medicationId, ...recentlyViewed?.filter(id => id !== medicationId)]?.slice(0, 10);
@@ -235,18 +234,8 @@ const MedicationDetails = () => {
     }, 800);
   }, [medicationId, isAuthenticated, navigate]);
 
-  const handleToggleFavorite = () => {
-    const favorites = JSON.parse(localStorage.getItem('clinicalDict_favorites') || '[]');
-    let updatedFavorites;
-    
-    if (isFavorite) {
-      updatedFavorites = favorites?.filter(id => id !== medicationId);
-    } else {
-      updatedFavorites = [...favorites, medicationId];
-    }
-    
-    localStorage.setItem('clinicalDict_favorites', JSON.stringify(updatedFavorites));
-    setIsFavorite(!isFavorite);
+const handleToggleFavorite = () => {
+    toggleFavorite(medicationId);
   };
 
   const handleShare = () => {
@@ -302,7 +291,7 @@ const MedicationDetails = () => {
             </div>
             <h2 className="text-xl font-semibold text-foreground">Medicamento no encontrado</h2>
             <p className="text-muted-foreground">No se pudo encontrar la información del medicamento solicitado.</p>
-            <Button onClick={() => navigate('/medication-search')}>
+            <Button onClick={() => navigate('/home')}>
               Volver a Búsqueda
             </Button>
           </div>

--- a/frontend/src/pages/medication-search/components/RecentSearches.jsx
+++ b/frontend/src/pages/medication-search/components/RecentSearches.jsx
@@ -8,7 +8,7 @@ const RecentSearches = ({ onSearchSelect }) => {
 
   useEffect(() => {
     const savedSearches = localStorage.getItem('clinicalDict_recentSearches');
-    const savedFavorites = localStorage.getItem('clinicalDict_favorites');
+    const savedFavorites = localStorage.getItem('sedo_favoritos_v1');
     
     if (savedSearches) {
       setRecentSearches(JSON.parse(savedSearches));

--- a/frontend/src/pages/medication-search/components/SearchBar.jsx
+++ b/frontend/src/pages/medication-search/components/SearchBar.jsx
@@ -1,9 +1,8 @@
 import React, { useState, useRef, useEffect } from 'react';
 import Icon from '../../../components/AppIcon';
 import Input from '../../../components/ui/Input';
-import Button from '../../../components/ui/Button';
 
-const SearchBar = ({ searchQuery, onSearchChange, onVoiceSearch, isVoiceActive }) => {
+const SearchBar = ({ searchQuery, onSearchChange }) => {
   const [showSuggestions, setShowSuggestions] = useState(false);
   const [recentSearches, setRecentSearches] = useState([]);
   const inputRef = useRef(null);
@@ -65,30 +64,19 @@ const SearchBar = ({ searchQuery, onSearchChange, onVoiceSearch, isVoiceActive }
         <Input
           ref={inputRef}
           type="search"
-          placeholder="Buscar medicamentos, protocolos, diluciones..."
+          placeholder="Buscar sedoanalgésicos, dosis, diluciones…"
           value={searchQuery}
           onChange={handleInputChange}
           onKeyPress={handleKeyPress}
           onFocus={() => setShowSuggestions(searchQuery?.length > 0)}
           onBlur={() => setTimeout(() => setShowSuggestions(false), 200)}
-          className="pl-12 pr-16 h-14 text-lg bg-white border-2 border-slate-200 rounded-xl focus:border-primary clinical-shadow"
+          className="pl-12 pr-4 h-14 text-lg bg-white border-2 border-slate-200 rounded-xl focus:border-primary clinical-shadow"
         />
-        <Icon 
-          name="Search" 
-          size={24} 
-          className="absolute left-4 top-1/2 transform -translate-y-1/2 text-slate-400" 
+        <Icon
+          name="Search"
+          size={24}
+          className="absolute left-4 top-1/2 transform -translate-y-1/2 text-slate-400"
         />
-        <Button
-          variant="ghost"
-          size="icon"
-          onClick={onVoiceSearch}
-          className={`absolute right-2 top-1/2 transform -translate-y-1/2 w-10 h-10 ${
-            isVoiceActive 
-              ? 'text-error bg-error/10 animate-pulse' :'text-slate-400 hover:text-primary hover:bg-primary/10'
-          }`}
-        >
-          <Icon name={isVoiceActive ? "MicOff" : "Mic"} size={20} />
-        </Button>
       </div>
       {/* Search Suggestions */}
       {showSuggestions && (filteredSuggestions?.length > 0 || recentSearches?.length > 0) && (

--- a/frontend/src/pages/medication-search/components/SearchResults.jsx
+++ b/frontend/src/pages/medication-search/components/SearchResults.jsx
@@ -1,3 +1,5 @@
+import { useFavorites } from "../../../utils/favorites";
+import { incrementSearchCount } from "../../../utils/searchMetrics";
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import Icon from '../../../components/AppIcon';
@@ -5,24 +7,19 @@ import Button from '../../../components/ui/Button';
 
 const SearchResults = ({ results, searchQuery, selectedCategory, isLoading }) => {
   const navigate = useNavigate();
+  const { favorites, toggleFavorite } = useFavorites();
 
   const handleMedicationClick = (medication) => {
-    navigate('/medication-details', { state: { medication } });
+    incrementSearchCount(medication.id);
+    navigate(`/medication-details?id=${medication.id}`);
   };
 
   const addToFavorites = (medicationId, e) => {
     e?.stopPropagation();
-    const favorites = JSON.parse(localStorage.getItem('clinicalDict_favorites') || '[]');
-    const updated = favorites?.includes(medicationId) 
-      ? favorites?.filter(id => id !== medicationId)
-      : [...favorites, medicationId];
-    localStorage.setItem('clinicalDict_favorites', JSON.stringify(updated));
+    toggleFavorite(medicationId);
   };
 
-  const isFavorite = (medicationId) => {
-    const favorites = JSON.parse(localStorage.getItem('clinicalDict_favorites') || '[]');
-    return favorites?.includes(medicationId);
-  };
+  const isFavorite = (medicationId) => favorites.includes(medicationId);
 
   if (isLoading) {
     return (

--- a/frontend/src/utils/favorites.js
+++ b/frontend/src/utils/favorites.js
@@ -1,0 +1,39 @@
+import { useState, useEffect } from 'react';
+
+const STORAGE_KEY = 'sedo_favoritos_v1';
+
+export const loadFavorites = () => {
+  try {
+    return JSON.parse(localStorage.getItem(STORAGE_KEY)) || [];
+  } catch {
+    return [];
+  }
+};
+
+export const saveFavorites = (favorites) => {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(favorites));
+};
+
+export const useFavorites = () => {
+  const [favorites, setFavorites] = useState([]);
+
+  useEffect(() => {
+    setFavorites(loadFavorites());
+  }, []);
+
+  const toggleFavorite = (id) => {
+    setFavorites(prev => {
+      const exists = prev.includes(id);
+      const updated = exists ? prev.filter(f => f !== id) : [...prev, id];
+      saveFavorites(updated);
+      return updated;
+    });
+  };
+
+  return { favorites, toggleFavorite };
+};
+
+export const isFavorite = (id) => {
+  const favorites = loadFavorites();
+  return favorites.includes(id);
+};

--- a/frontend/src/utils/searchMetrics.js
+++ b/frontend/src/utils/searchMetrics.js
@@ -1,0 +1,36 @@
+const STORAGE_KEY = 'sedo_busquedas_v1';
+const TTL = 30 * 24 * 60 * 60 * 1000; // 30 days
+
+const loadMetrics = () => {
+  try {
+    const data = JSON.parse(localStorage.getItem(STORAGE_KEY)) || {};
+    const now = Date.now();
+    const cleaned = {};
+    Object.entries(data).forEach(([id, info]) => {
+      if (now - (info.timestamp || 0) < TTL) {
+        cleaned[id] = info;
+      }
+    });
+    if (Object.keys(cleaned).length !== Object.keys(data).length) {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(cleaned));
+    }
+    return cleaned;
+  } catch {
+    return {};
+  }
+};
+
+export const incrementSearchCount = (id) => {
+  const metrics = loadMetrics();
+  const entry = metrics[id] || { count: 0, timestamp: 0 };
+  metrics[id] = { count: entry.count + 1, timestamp: Date.now() };
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(metrics));
+};
+
+export const getTopSearches = (limit = 8) => {
+  const metrics = loadMetrics();
+  return Object.entries(metrics)
+    .sort((a, b) => b[1].count - a[1].count)
+    .slice(0, limit)
+    .map(([id]) => id);
+};


### PR DESCRIPTION
## Summary
- create mobile-first home with Novedades, Más buscados y Mis favoritos
- track favoritos and búsquedas in localStorage
- wire home route and update navigation and search metrics
- polish home layout with category shortcuts, atajos and floating voice search

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68b8894298d48329a8338ff42d54c564