### PR TITLE
feat: simplificar fondo de home

### DIFF
--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -12,11 +12,6 @@ body {
 }
 
 .hex-bg {
-  background-color: #f8fafc;
-  background-image:
-    linear-gradient(30deg, rgba(59,130,246,0.15) 12%, transparent 12.5%, transparent 87%, rgba(59,130,246,0.15) 87.5%, rgba(59,130,246,0.15)),
-    linear-gradient(150deg, rgba(59,130,246,0.15) 12%, transparent 12.5%, transparent 87%, rgba(59,130,246,0.15) 87.5%, rgba(59,130,246,0.15)),
-    linear-gradient(90deg, rgba(59,130,246,0.15) 2%, transparent 2.5%, transparent 97%, rgba(59,130,246,0.15) 97.5%, rgba(59,130,246,0.15));
-  background-size: 60px 104px;
-  background-position: 0 0, 0 0, 0 0;
+  /* Plain light blue-tinted background without pattern */
+  background-color: #f8fbff;
 }


### PR DESCRIPTION
## Summary
- replace diamond background with plain light-blue background

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: [vite] Rollup failed to resolve import "firebase/firestore" from "src/pages/medication-search/index.jsx")*

------
https://chatgpt.com/codex/tasks/task_b_68b89c332c808329813ac08c0256161d