### PR TITLE
feat: add medication detail tab

### DIFF
--- a/frontend/src/pages/medication-details/components/MedicationDetailTab.jsx
+++ b/frontend/src/pages/medication-details/components/MedicationDetailTab.jsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import Icon from '../../../components/AppIcon';
+
+const Section = ({ icon, title, children }) => (
+  <div className="bg-card border border-border rounded-lg p-4 lg:p-6">
+    <div className="flex items-center space-x-3 mb-4">
+      <div className="flex items-center justify-center w-10 h-10 bg-primary/10 rounded-lg">
+        <Icon name={icon} size={24} className="text-primary" />
+      </div>
+      <h2 className="text-xl font-semibold text-foreground">{title}</h2>
+    </div>
+    {children}
+  </div>
+);
+
+const fieldOrNA = (value) => {
+  if (!value || String(value).trim() === '') return 'No especificado';
+  return value;
+};
+
+const MedicationDetailTab = ({ medication }) => {
+  return (
+    <div className="space-y-6">
+      <Section icon="Activity" title="Dosis">
+        <p className="text-2xl font-bold text-primary">
+          {medication?.dosage ? `${medication.dosage} ${medication?.dosageUnit || ''}` : 'No especificado'}
+        </p>
+      </Section>
+
+      <Section icon="AlertTriangle" title="Advertencias">
+        <p className="text-base text-foreground">{fieldOrNA(medication?.warnings)}</p>
+      </Section>
+
+      <Section icon="Syringe" title="Vía de administración">
+        <p className="text-base text-foreground">{fieldOrNA(medication?.administration)}</p>
+      </Section>
+
+      <Section icon="Beaker" title="Concentración y dilución">
+        <p className="text-base text-foreground">{fieldOrNA(medication?.concentration)}</p>
+        {medication?.dilution && (
+          <p className="text-base text-foreground mt-2 whitespace-pre-line">{medication.dilution}</p>
+        )}
+      </Section>
+
+      <Section icon="Clock" title="Tiempo de administración y rango de seguridad">
+        <p className="text-base text-foreground">{fieldOrNA(medication?.administrationTime)}</p>
+      </Section>
+
+      <Section icon="Timer" title="Estabilidad">
+        <p className="text-base text-foreground">{fieldOrNA(medication?.stability)}</p>
+      </Section>
+
+      <Section icon="Sun" title="Fotosensibilidad">
+        <p className="text-base text-foreground">{fieldOrNA(medication?.lightProtection)}</p>
+      </Section>
+
+      <Section icon="GitMerge" title="Compatibilidad en Y">
+        {medication?.incompatibilities && medication.incompatibilities.length > 0 ? (
+          <ul className="list-disc pl-5 space-y-1 text-base text-foreground">
+            {medication.incompatibilities.map((item, index) => (
+              <li key={index}>{item}</li>
+            ))}
+          </ul>
+        ) : (
+          <p className="text-base text-foreground">No especificado</p>
+        )}
+      </Section>
+
+      <Section icon="FileText" title="Observaciones">
+        <p className="text-base text-foreground whitespace-pre-line">{fieldOrNA(medication?.observations)}</p>
+      </Section>
+    </div>
+  );
+};
+
+export default MedicationDetailTab;

--- a/frontend/src/pages/medication-details/index.jsx
+++ b/frontend/src/pages/medication-details/index.jsx
@@ -3,10 +3,7 @@ import { useSearchParams, useNavigate } from 'react-router-dom';
 import ClinicalSearchHeader from '../../components/ui/ClinicalSearchHeader';
 import { useNavigation } from '../../components/ui/RoleBasedNavigation';
 import MedicationHeader from './components/MedicationHeader';
-import SafetyInformation from './components/SafetyInformation';
-import DosageConcentration from './components/DosageConcentration';
-import WarningsIncompatibilities from './components/WarningsIncompatibilities';
-import ClinicalObservations from './components/ClinicalObservations';
+import MedicationDetailTab from './components/MedicationDetailTab';
 import QuickActions from './components/QuickActions';
 import Icon from '../../components/AppIcon';
 import Button from '../../components/ui/Button';
@@ -17,7 +14,7 @@ import medicationsData from '../../../FARMACOTECA_REORGANIZADA.json';
 const MedicationDetails = () => {
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
-  const { isAuthenticated, userRole } = useNavigation();
+  const { isAuthenticated } = useNavigation();
   const [medication, setMedication] = useState(null);
   const [isFavorite, setIsFavorite] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
@@ -37,16 +34,19 @@ const MedicationDetails = () => {
       id: medicationId,
       name: rawData.Medicamento,
       presentation: rawData.Presentacion,
-      dosage: rawData["Dosis de seguridad"],
-      administration: rawData["Via / Forma de administracion"],
+      dosage: rawData['Dosis de seguridad'],
+      administration: rawData['Via / Forma de administracion'],
       concentration: rawData.Concentracion,
       dilution: rawData.Dilucion,
-      incompatibilities: rawData.Incompatibilidades,
+      incompatibilities: rawData.Incompatibilidades
+        ? rawData.Incompatibilidades.split(',').map(item => item.trim())
+        : [],
       observations: rawData.Observaciones,
-      stability: rawData["Estabilidad de la dilucion"],
-      lightProtection: rawData["Proteccion de la luz"],
-      administrationTime: rawData["Tiempo de administracion"],
-      dosageUnit: rawData["Unidad de dosificacion"]
+      stability: rawData['Estabilidad de la dilucion'],
+      lightProtection: rawData['Proteccion de la luz'],
+      administrationTime: rawData['Tiempo de administracion'],
+      dosageUnit: rawData['Unidad de dosificacion'],
+      warnings: rawData.Advertencias || null,
     } : null;
     if (data) {
       setMedication(data);
@@ -158,10 +158,7 @@ const MedicationDetails = () => {
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 p-4 lg:p-6">
           {/* Main Content */}
           <div className="lg:col-span-2 space-y-6">
-            <SafetyInformation medication={medication} />
-            <DosageConcentration medication={medication} />
-            <WarningsIncompatibilities medication={medication} />
-            <ClinicalObservations medication={medication} />
+            <MedicationDetailTab medication={medication} />
           </div>
 
           {/* Sidebar */}


### PR DESCRIPTION
## Summary
- show medication details in organized Spanish cards
- parse dataset fields for dose, administration, stability and more

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68b8a4583cdc8329a0ae99e088751e7f