### PR TITLE
Display medication info in modal

### DIFF
--- a/frontend/src/pages/medication-search/components/MedicationModal.jsx
+++ b/frontend/src/pages/medication-search/components/MedicationModal.jsx
@@ -1,0 +1,96 @@
+import React from 'react';
+import Icon from '../../../components/AppIcon';
+import Button from '../../../components/ui/Button';
+
+const MedicationModal = ({ medication, onClose }) => {
+  if (!medication) return null;
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+      <div className="bg-white rounded-lg max-w-2xl w-full max-h-full overflow-y-auto p-6 relative">
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={onClose}
+          className="absolute top-4 right-4"
+        >
+          <Icon name="X" size={18} />
+        </Button>
+        <h3 className="text-xl font-semibold mb-4 text-slate-800">
+          {medication.name}
+        </h3>
+        <div className="space-y-2 text-slate-700 text-sm">
+          {medication.presentation && (
+            <div>
+              <span className="font-medium">Presentación: </span>
+              {medication.presentation}
+            </div>
+          )}
+          {medication.dosage && (
+            <div>
+              <span className="font-medium">Dosis de seguridad: </span>
+              {medication.dosage}
+              {medication.dosageUnit && ` (${medication.dosageUnit})`}
+            </div>
+          )}
+          {medication.administration && (
+            <div>
+              <span className="font-medium">Vía de administración: </span>
+              {medication.administration}
+            </div>
+          )}
+          {medication.administrationTime && (
+            <div>
+              <span className="font-medium">Tiempo de administración: </span>
+              {medication.administrationTime}
+            </div>
+          )}
+          {medication.concentration && (
+            <div>
+              <span className="font-medium">Concentración: </span>
+              {medication.concentration}
+            </div>
+          )}
+          {medication.dilution && (
+            <div>
+              <span className="font-medium">Dilución: </span>
+              {medication.dilution}
+            </div>
+          )}
+          {medication.stability && (
+            <div>
+              <span className="font-medium">Estabilidad de la dilución: </span>
+              {medication.stability}
+            </div>
+          )}
+          {medication.lightProtection && (
+            <div>
+              <span className="font-medium">Protección de la luz: </span>
+              {medication.lightProtection}
+            </div>
+          )}
+          {medication.incompatibilities && (
+            <div>
+              <span className="font-medium">Incompatibilidades: </span>
+              {medication.incompatibilities}
+            </div>
+          )}
+          {medication.observations && (
+            <div>
+              <span className="font-medium">Observaciones: </span>
+              <p className="whitespace-pre-line mt-1">{medication.observations}</p>
+            </div>
+          )}
+          {medication.warnings && (
+            <div>
+              <span className="font-medium">Advertencias: </span>
+              {medication.warnings}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default MedicationModal;

--- a/frontend/src/pages/medication-search/components/SearchResults.jsx
+++ b/frontend/src/pages/medication-search/components/SearchResults.jsx
@@ -1,17 +1,13 @@
-import React, { useState, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
+import React, { useState } from 'react';
 import Icon from '../../../components/AppIcon';
 import Button from '../../../components/ui/Button';
-import { getCurrentLocation } from '../../../utils/geoLocation';
+import MedicationModal from './MedicationModal';
 
 const SearchResults = ({ results, searchQuery, isLoading, hasMedications }) => {
-  const navigate = useNavigate();
-  const [locationError, setLocationError] = useState(null);
-  const [isLocationVerified, setIsLocationVerified] = useState(false);
-  const [isCheckingLocation, setIsCheckingLocation] = useState(true);
+  const [selectedMedication, setSelectedMedication] = useState(null);
 
   const handleMedicationClick = (medication) => {
-    navigate(`/medication-details?id=${medication?.id}`);
+    setSelectedMedication(medication);
   };
 
   const addToFavorites = (medicationId, e) => {
@@ -89,6 +85,7 @@ const SearchResults = ({ results, searchQuery, isLoading, hasMedications }) => {
   }
 
   return (
+    <>
     <div className="w-full max-w-6xl mx-auto">
       <div className="flex items-center justify-between mb-6">
         <div>
@@ -153,6 +150,13 @@ const SearchResults = ({ results, searchQuery, isLoading, hasMedications }) => {
         ))}
       </div>
     </div>
+    {selectedMedication && (
+      <MedicationModal
+        medication={selectedMedication}
+        onClose={() => setSelectedMedication(null)}
+      />
+    )}
+    </>
   );
 };
 

--- a/frontend/src/pages/medication-search/index.jsx
+++ b/frontend/src/pages/medication-search/index.jsx
@@ -28,7 +28,12 @@ const MedicationSearch = () => {
       concentration: med.Concentracion,
       dilution: med.Dilucion,
       incompatibilities: med.Incompatibilidades,
-      observations: med.Observaciones
+      observations: med.Observaciones,
+      administrationTime: med["Tiempo de administracion"],
+      dosageUnit: med["Unidad de dosificacion"],
+      stability: med["Estabilidad de la dilucion"],
+      lightProtection: med["Proteccion de la luz"],
+      warnings: med.Advertencias
     }));
     setMedications(transformedData);
   }, []);


### PR DESCRIPTION
## Summary
- Expand medication data mapping to include all fields from FARMACOTECA_REORGANIZADA.json.
- Replace navigation with an in-page modal to show medication details on click.
- Introduce reusable `MedicationModal` component styled with TailwindCSS.

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_68b8ef1d41ac832ea33e283ff6816df6