### PR TITLE
Display medication info in modal

### DIFF
--- a/frontend/src/pages/medication-search/components/MedicationModal.jsx
+++ b/frontend/src/pages/medication-search/components/MedicationModal.jsx
@@ -1,0 +1,119 @@
+import React, { useEffect } from 'react';
+import Icon from '../../../components/AppIcon';
+import Button from '../../../components/ui/Button';
+
+const MedicationModal = ({ medication, onClose }) => {
+  useEffect(() => {
+    if (medication && typeof window !== 'undefined') {
+      const synth = window.speechSynthesis;
+      if (synth) {
+        const parts = [];
+        if (medication.dosage) parts.push(`Dosis de seguridad: ${medication.dosage}`);
+        if (medication.dilution) parts.push(`Dilución: ${medication.dilution}`);
+        if (medication.lightProtection) parts.push(`Protección a la luz: ${medication.lightProtection}`);
+        const utterance = new SpeechSynthesisUtterance(parts.join('. '));
+        utterance.lang = 'es-ES';
+        synth.cancel();
+        synth.speak(utterance);
+        return () => synth.cancel();
+      }
+    }
+  }, [medication]);
+
+  if (!medication) return null;
+
+  return (
+    <div className="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center z-50 p-4">
+      <div className="bg-white rounded-xl shadow-2xl w-full max-w-2xl max-h-[90vh] overflow-y-auto">
+        <div className="bg-gradient-to-r from-indigo-500 via-sky-500 to-cyan-500 p-6 flex justify-between items-center">
+          <h3 className="text-2xl font-semibold text-white">
+            {medication.name}
+          </h3>
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={onClose}
+            className="text-white hover:bg-white/20"
+          >
+            <Icon name="X" size={18} />
+          </Button>
+        </div>
+        <div className="p-6 space-y-6 text-slate-700 text-sm">
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            {medication.presentation && (
+              <div>
+                <h4 className="font-medium text-slate-600">Presentación</h4>
+                <p className="text-slate-800">{medication.presentation}</p>
+              </div>
+            )}
+            {medication.dosage && (
+              <div>
+                <h4 className="font-medium text-slate-600">Dosis de seguridad</h4>
+                <p className="text-slate-800">
+                  {medication.dosage}
+                  {medication.dosageUnit && ` (${medication.dosageUnit})`}
+                </p>
+              </div>
+            )}
+            {medication.administration && (
+              <div>
+                <h4 className="font-medium text-slate-600">Vía de administración</h4>
+                <p className="text-slate-800">{medication.administration}</p>
+              </div>
+            )}
+            {medication.administrationTime && (
+              <div>
+                <h4 className="font-medium text-slate-600">Tiempo de administración</h4>
+                <p className="text-slate-800">{medication.administrationTime}</p>
+              </div>
+            )}
+            {medication.concentration && (
+              <div>
+                <h4 className="font-medium text-slate-600">Concentración</h4>
+                <p className="text-slate-800">{medication.concentration}</p>
+              </div>
+            )}
+            {medication.dilution && (
+              <div>
+                <h4 className="font-medium text-slate-600">Dilución</h4>
+                <p className="text-slate-800">{medication.dilution}</p>
+              </div>
+            )}
+            {medication.stability && (
+              <div>
+                <h4 className="font-medium text-slate-600">Estabilidad de la dilución</h4>
+                <p className="text-slate-800">{medication.stability}</p>
+              </div>
+            )}
+            {medication.lightProtection && (
+              <div>
+                <h4 className="font-medium text-slate-600">Protección de la luz</h4>
+                <p className="text-slate-800">{medication.lightProtection}</p>
+              </div>
+            )}
+            {medication.incompatibilities && (
+              <div className="sm:col-span-2">
+                <h4 className="font-medium text-slate-600">Incompatibilidades</h4>
+                <p className="text-slate-800">{medication.incompatibilities}</p>
+              </div>
+            )}
+            {medication.warnings && (
+              <div className="sm:col-span-2">
+                <h4 className="font-medium text-slate-600">Advertencias</h4>
+                <p className="text-slate-800">{medication.warnings}</p>
+              </div>
+            )}
+          </div>
+          {medication.observations && (
+            <div>
+              <h4 className="font-medium text-slate-600">Observaciones</h4>
+              <p className="whitespace-pre-line mt-1 text-slate-800">{medication.observations}</p>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default MedicationModal;

--- a/frontend/src/pages/medication-search/components/SearchResults.jsx
+++ b/frontend/src/pages/medication-search/components/SearchResults.jsx
@@ -1,17 +1,13 @@
-import React, { useState, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
+import React, { useState } from 'react';
 import Icon from '../../../components/AppIcon';
 import Button from '../../../components/ui/Button';
-import { getCurrentLocation } from '../../../utils/geoLocation';
+import MedicationModal from './MedicationModal';
 
 const SearchResults = ({ results, searchQuery, isLoading, hasMedications }) => {
-  const navigate = useNavigate();
-  const [locationError, setLocationError] = useState(null);
-  const [isLocationVerified, setIsLocationVerified] = useState(false);
-  const [isCheckingLocation, setIsCheckingLocation] = useState(true);
+  const [selectedMedication, setSelectedMedication] = useState(null);
 
   const handleMedicationClick = (medication) => {
-    navigate(`/medication-details?id=${medication?.id}`);
+    setSelectedMedication(medication);
   };
 
   const addToFavorites = (medicationId, e) => {
@@ -89,6 +85,7 @@ const SearchResults = ({ results, searchQuery, isLoading, hasMedications }) => {
   }
 
   return (
+    <>
     <div className="w-full max-w-6xl mx-auto">
       <div className="flex items-center justify-between mb-6">
         <div>
@@ -153,6 +150,13 @@ const SearchResults = ({ results, searchQuery, isLoading, hasMedications }) => {
         ))}
       </div>
     </div>
+    {selectedMedication && (
+      <MedicationModal
+        medication={selectedMedication}
+        onClose={() => setSelectedMedication(null)}
+      />
+    )}
+    </>
   );
 };
 

--- a/frontend/src/pages/medication-search/index.jsx
+++ b/frontend/src/pages/medication-search/index.jsx
@@ -28,7 +28,12 @@ const MedicationSearch = () => {
       concentration: med.Concentracion,
       dilution: med.Dilucion,
       incompatibilities: med.Incompatibilidades,
-      observations: med.Observaciones
+      observations: med.Observaciones,
+      administrationTime: med["Tiempo de administracion"],
+      dosageUnit: med["Unidad de dosificacion"],
+      stability: med["Estabilidad de la dilucion"],
+      lightProtection: med["Proteccion de la luz"],
+      warnings: med.Advertencias
     }));
     setMedications(transformedData);
   }, []);


### PR DESCRIPTION
## Summary
- Add speech synthesis to read safety dose, dilution and light protection when a medication modal opens.
- Refresh modal UI with gradient header and responsive grid layout for clearer details.

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68b8ef1d41ac832ea33e283ff6816df6