### PR TITLE
feat: enhance medication modal with speech

### DIFF
--- a/frontend/src/pages/medication-search/components/MedicationModal.jsx
+++ b/frontend/src/pages/medication-search/components/MedicationModal.jsx
@@ -1,25 +1,65 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import Icon from '../../../components/AppIcon';
 import Button from '../../../components/ui/Button';
 
 const MedicationModal = ({ medication, onClose }) => {
+  useEffect(() => {
+    if (!medication || !('speechSynthesis' in window)) return;
+
+    const parts = [`Nombre del medicamento: ${medication.name}`];
+
+    if (medication.dosage) {
+      parts.push(
+        `Dosis de seguridad: ${medication.dosage}${
+          medication.dosageUnit ? ` ${medication.dosageUnit}` : ''
+        }`
+      );
+    }
+
+    if (medication.stability) {
+      parts.push(`Estabilidad de la dilución: ${medication.stability}`);
+    }
+
+    if (medication.lightProtection) {
+      parts.push(`Protección a la luz: ${medication.lightProtection}`);
+    }
+
+    const utterance = new SpeechSynthesisUtterance(parts.join('. '));
+    utterance.lang = 'es-ES';
+    window.speechSynthesis.cancel();
+    window.speechSynthesis.speak(utterance);
+
+    return () => window.speechSynthesis.cancel();
+  }, [medication]);
+
   if (!medication) return null;
 
+  const handleOverlayClick = (e) => {
+    if (e.target === e.currentTarget) {
+      onClose();
+    }
+  };
+
   return (
-    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
-      <div className="bg-white rounded-lg max-w-2xl w-full max-h-full overflow-y-auto p-6 relative">
-        <Button
-          variant="ghost"
-          size="icon"
-          onClick={onClose}
-          className="absolute top-4 right-4"
-        >
-          <Icon name="X" size={18} />
-        </Button>
-        <h3 className="text-xl font-semibold mb-4 text-slate-800">
-          {medication.name}
-        </h3>
-        <div className="space-y-2 text-slate-700 text-sm">
+    <div
+      className="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center z-50 p-4"
+      onClick={handleOverlayClick}
+    >
+      <div className="bg-white rounded-2xl shadow-2xl max-w-2xl w-full max-h-full overflow-y-auto relative transform transition-all animate-in fade-in zoom-in">
+        <div className="bg-gradient-to-r from-indigo-500 to-blue-500 p-6 rounded-t-2xl">
+          <h3 className="text-xl font-semibold text-white text-center">
+            {medication.name}
+          </h3>
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={onClose}
+            className="absolute top-4 right-4 text-white"
+          >
+            <Icon name="X" size={18} />
+          </Button>
+        </div>
+        <div className="p-6 space-y-3 text-slate-700 text-sm">
           {medication.presentation && (
             <div>
               <span className="font-medium">Presentación: </span>


### PR DESCRIPTION
## Summary
- polish medication modal with gradient header and animated overlay
- narrate key medication details via Web Speech API when opening modal

## Testing
- `cd frontend && npm test` *(fails: Missing script "test")*
- `cd server && npm test` *(fails: Error: Expected a semicolon)*

------
https://chatgpt.com/codex/tasks/task_b_68b8f2a904d4832e81943e3d5cdf3ac3