### PR TITLE
Fix Vercel output directory for frontend build

### DIFF
--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -6,7 +6,7 @@
     }
   ],
   "buildCommand": "npm run build",
-  "outputDirectory": "dist",
+  "outputDirectory": "build",
   "framework": "vite",
   "installCommand": "npm install"
 }


### PR DESCRIPTION
## Summary
- correct Vercel configuration to match Vite build output

## Testing
- `cd frontend && npm run build`

------
https://chatgpt.com/codex/tasks/task_b_68b8f654e65c832e805b95de1bacdd84